### PR TITLE
Add `go-source` meta tag

### DIFF
--- a/line-bot-sdk/index.html
+++ b/line-bot-sdk/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="go.linecorp.com/line-bot-sdk git https://github.com/line/line-bot-sdk-go">
+<meta name="go-source" content="go.linecorp.com/line-bot-sdk https://github.com/line/line-bot-sdk-go/ https://github.com/line/line-bot-sdk-go/tree/master{/dir} https://github.com/line/line-bot-sdk-go/tree/master{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://godoc.org/go.linecorp.com/line-bot-sdk">
 </head>
 <body>

--- a/line-bot-sdk/linebot/index.html
+++ b/line-bot-sdk/linebot/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="go-import" content="go.linecorp.com/line-bot-sdk/linebot git https://github.com/line/line-bot-sdk-go">
+    <meta name="go-source" content="go.linecorp.com/line-bot-sdk https://github.com/line/line-bot-sdk-go/ https://github.com/line/line-bot-sdk-go/tree/master{/dir} https://github.com/line/line-bot-sdk-go/tree/master{/dir}/{file}#L{line}">
     <meta http-equiv="refresh" content="0; url=https://godoc.org/go.linecorp.com/line-bot-sdk/linebot">
 </head>
 


### PR DESCRIPTION
ref. #2 
It seems that `go-source` meta tag is needed for `godoc.org`.
https://github.com/golang/gddo/wiki/Source-Code-Links